### PR TITLE
Fix: determine changes correctly for (new) PRs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,10 +14,10 @@
     <version>1.0.11-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Pipeline: Multibranch build strategy extension</name>
-    
+
     <description>This plugin provides additional configuration for multi branch build strategies.</description>
-    
-    
+
+
     <url>https://wiki.jenkins.io/display/JENKINS/Multibranch+Build+Strategy+Extension+Plugin</url>
 
     <properties>
@@ -41,7 +41,7 @@
             <email>igal.gluh@gmail.com</email>
         </developer>
     </developers>
-    
+
     <scm>
         <connection>scm:git:ssh://git@github.com/jenkinsci/multibranch-build-strategy-extension.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/multibranch-build-strategy-extension.git</developerConnection>
@@ -79,8 +79,8 @@
             <artifactId>junit</artifactId>
             <version>1.3</version>
         </dependency>
-        
-        
+
+
         <!-- plugin dependencies -->
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -102,12 +102,17 @@
             <artifactId>branch-api</artifactId>
             <version>2.0.17</version>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>github-branch-source</artifactId>
+            <version>2.3.2</version>
+        </dependency>
         <!-- /plugin dependencies -->
-        
-        
-        
-        
-        
+
+
+
+
+
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
@@ -120,10 +125,10 @@
             <version>1.6.4</version>
             <scope>test</scope>
         </dependency>
-       
-       
-       
-       
+
+
+
+
         <!-- For interactive testing via hpi:run -->
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -177,12 +182,6 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-aggregator</artifactId>
             <version>2.5</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>github-branch-source</artifactId>
-            <version>2.3.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/igalg/jenkins/plugins/multibranch/buildstrategy/ActuallyUsefulGitHubSCMSource.java
+++ b/src/main/java/com/igalg/jenkins/plugins/multibranch/buildstrategy/ActuallyUsefulGitHubSCMSource.java
@@ -1,0 +1,21 @@
+package com.igalg.jenkins.plugins.multibranch.buildstrategy;
+
+import java.io.IOException;
+
+import hudson.model.TaskListener;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMRevision;
+
+import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
+
+
+public class ActuallyUsefulGitHubSCMSource extends GitHubSCMSource {
+
+  public ActuallyUsefulGitHubSCMSource(String id, String apiUri, String checkoutCredentialsId, String scanCredentialsId, String repoOwner, String repository) {
+    super(id, apiUri, checkoutCredentialsId, scanCredentialsId, repoOwner, repository);
+  }
+
+  SCMRevision getCommitHash(SCMHead head, TaskListener listener) throws IOException, InterruptedException {
+    return super.retrieve(head, listener);
+  }
+}

--- a/src/main/java/com/igalg/jenkins/plugins/multibranch/buildstrategy/BranchBuildStrategyExtension.java
+++ b/src/main/java/com/igalg/jenkins/plugins/multibranch/buildstrategy/BranchBuildStrategyExtension.java
@@ -44,48 +44,44 @@ import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceOwner;
 
-public abstract class BranchBuildStrategyExtension extends BranchBuildStrategy{
 
-		private final static int HASH_LENGTH = 40;
-		private static final Logger logger = Logger.getLogger(BranchBuildStrategyExtension.class.getName());
-	
-	   protected SCMFileSystem   buildSCMFileSystem(SCMSource source, SCMHead head, SCMRevision currRevision,SCM scm,SCMSourceOwner owner) throws Exception{
-	    	GitSCMFileSystem.Builder builder = new GitSCMFileSystem.BuilderImpl(); 
-	    	if (currRevision != null && !(currRevision instanceof AbstractGitSCMSource.SCMRevisionImpl))
-	             return builder.build(source, head, new AbstractGitSCMSource.SCMRevisionImpl(head, currRevision.toString().substring(0,40)));
-	         else 
-	             return builder.build(owner, scm, currRevision);
-	    }
-	    
-	    
-	   protected List<GitChangeSet> getGitChangeSetListFromPrevious(SCMFileSystem fileSystem,SCMHead head, SCMRevision prevRevision) throws Exception{
-	        ByteArrayOutputStream out = new ByteArrayOutputStream();
-	        if (prevRevision != null && !(prevRevision instanceof AbstractGitSCMSource.SCMRevisionImpl))
-	            fileSystem.changesSince(new AbstractGitSCMSource.SCMRevisionImpl(head,prevRevision.toString().substring(0,HASH_LENGTH)), out);
-	        else 
-	            fileSystem.changesSince(prevRevision, out);	        
-	        GitChangeLogParser parser = new GitChangeLogParser(true);
-	        return parser.parse(new ByteArrayInputStream(out.toByteArray()));
-	    }
-	    
-	    
-	   protected Set<String> collectAllAffectedFiles(List<GitChangeSet> gitChangeSetList) {
-	    	Set<String> pathesSet = new HashSet<String>();
-	        for (GitChangeSet gitChangeSet : gitChangeSetList) {
-	        	List<Path> affectedFilesList = new ArrayList<Path>(gitChangeSet.getAffectedFiles());
-	        	for (Path path : affectedFilesList) {
-	        		pathesSet.add(path.getPath());
-	        		logger.fine("File:" + path.getPath() +" from commit:" + gitChangeSet.getCommitId() + " Change type:" + path.getEditType().getName());
-	        	}
-	        }
-	        return pathesSet;
-	    }
-	   
-	   protected Set<String> collectAllComments(List<GitChangeSet> gitChangeSetList) {
-	    	Set<String> comments = new HashSet<String>();
-	        for (GitChangeSet gitChangeSet : gitChangeSetList) {
-	        	comments.add(gitChangeSet.getComment());
-	        }
-	        return comments;
-	    }
+public abstract class BranchBuildStrategyExtension extends BranchBuildStrategy {
+  private final static int HASH_LENGTH = 40;
+  private static final Logger logger = Logger.getLogger(BranchBuildStrategyExtension.class.getName());
+
+  protected SCMFileSystem buildSCMFileSystem(SCMSource source, SCMHead head, SCMRevision currRevision, SCM scm, SCMSourceOwner owner) throws Exception {
+    GitSCMFileSystem.Builder builder = new GitSCMFileSystem.BuilderImpl();
+  	if (currRevision != null && !(currRevision instanceof AbstractGitSCMSource.SCMRevisionImpl))
+      return builder.build(source, head, new AbstractGitSCMSource.SCMRevisionImpl(head, currRevision.toString().substring(0,40)));
+    else
+      return builder.build(owner, scm, currRevision);
+  }
+
+  protected List<GitChangeSet> getGitChangeSetListFromPrevious(SCMFileSystem fileSystem, SCMHead head, SCMRevision prevRevision) throws Exception {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    fileSystem.changesSince(prevRevision, out);
+    logger.fine(out.toString("UTF-8"));
+    GitChangeLogParser parser = new GitChangeLogParser(true);
+    return parser.parse(new ByteArrayInputStream(out.toByteArray()));
+  }
+
+  protected Set<String> collectAllAffectedFiles(List<GitChangeSet> gitChangeSetList) {
+  	Set<String> pathsSet = new HashSet<String>();
+    for (GitChangeSet gitChangeSet : gitChangeSetList) {
+    	List<Path> affectedFilesList = new ArrayList<Path>(gitChangeSet.getAffectedFiles());
+    	for (Path path : affectedFilesList) {
+        pathsSet.add(path.getPath());
+        logger.fine("File:" + path.getPath() +" from commit:" + gitChangeSet.getCommitId() + " Change type:" + path.getEditType().getName());
+    	}
+    }
+    return pathsSet;
+  }
+
+  protected Set<String> collectAllComments(List<GitChangeSet> gitChangeSetList) {
+  	Set<String> comments = new HashSet<String>();
+    for (GitChangeSet gitChangeSet : gitChangeSetList) {
+    	comments.add(gitChangeSet.getComment());
+    }
+    return comments;
+  }
 }

--- a/src/main/java/com/igalg/jenkins/plugins/multibranch/buildstrategy/IncludeRegionBranchBuildStrategy.java
+++ b/src/main/java/com/igalg/jenkins/plugins/multibranch/buildstrategy/IncludeRegionBranchBuildStrategy.java
@@ -23,7 +23,6 @@
  */
 package com.igalg.jenkins.plugins.multibranch.buildstrategy;
 
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -36,100 +35,122 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import hudson.Extension;
 import hudson.scm.SCM;
+import hudson.util.LogTaskListener;
 import jenkins.branch.BranchBuildStrategyDescriptor;
 import jenkins.scm.api.SCMFileSystem;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceOwner;
+import jenkins.plugins.git.AbstractGitSCMSource;
+import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
+import org.jenkinsci.plugins.github_branch_source.PullRequestSCMHead;
+
 
 public class IncludeRegionBranchBuildStrategy extends BranchBuildStrategyExtension {
-    
-	private static final Logger logger = Logger.getLogger(IncludeRegionBranchBuildStrategy.class.getName());
+  private static final Logger logger = Logger.getLogger(IncludeRegionBranchBuildStrategy.class.getName());
     private final String includedRegions;
-    
-    public String getIncludedRegions() {
-		return includedRegions;
-	}
 
+  public String getIncludedRegions() {
+    return includedRegions;
+  }
 
-    @DataBoundConstructor
-    public IncludeRegionBranchBuildStrategy(String includedRegions) {
-        this.includedRegions = includedRegions;
-    }
+  @DataBoundConstructor
+  public IncludeRegionBranchBuildStrategy(String includedRegions) {
+    this.includedRegions = includedRegions;
+  }
 
-    
+  /**
+   * Determine if build is required by checking if any of the commit affected files is in the include regions.
+   *
+   * @return true if there is at least one affected file in the include regions
+   */
+  @Override
+  public boolean isAutomaticBuild(SCMSource source, SCMHead head, SCMRevision currRevision, SCMRevision prevRevision) {
+    try {
+      logger.info(String.format("Checking if %s needs to be built", head.getName()));
+      // We always want to determine the changed files between the PR's branch and the target branch
+      // For the first build of every PR prevRevision is set to null, this causes the diff to determine
+      // the changed files to include all commits ever done to the repo which means it also includes all
+      // files ever touched in the repo which means the first build will always trigger.
+      // To fix this we determine the revision (commit) of the target branch and use that instead of prevRevision
+      if(source instanceof GitHubSCMSource && head instanceof PullRequestSCMHead){
+        logger.info("Getting merge target revision hash from GitHubSCMSource");
+        logger.fine(String.format("prevRevision before: %s", prevRevision));
 
-   
-    /**
-     * Determine if build is required by checking if any of the commit affected files is in the include regions.
-     *
-     * @return true if  there is at least one affected file in the include regions 
-     */
-    @Override
-    public boolean isAutomaticBuild(SCMSource source, SCMHead head, SCMRevision currRevision, SCMRevision prevRevision) {
-        try {
-        	
-        	 List<String> includedRegionsList = Arrays.stream(
-             		includedRegions.split("\n")).map(e -> e.trim()).collect(Collectors.toList());
+        GitHubSCMSource ghSource = (GitHubSCMSource) source;
+        SCMHead targetHead = ((PullRequestSCMHead) head).getTarget();
+        logger.fine(String.format("targetHead: %s", targetHead));
 
-             logger.info(String.format("Included regions: %s", includedRegionsList.toString()));
-             
-             // No regions included cancel the build
-             if(includedRegionsList.isEmpty())
-             	return false;
-        	
-        	
-        	// build SCM object
-        	SCM scm = source.build(head, currRevision);
-            
-  
-        	// Verify source owner
-        	SCMSourceOwner owner = source.getOwner();
-            if (owner == null) {
-                logger.severe("Error verify SCM source owner");
-                return true;
-            }
-            
-            
-            // Build SCM file system
-            SCMFileSystem fileSystem = buildSCMFileSystem(source,head,currRevision,scm,owner);            
-            if (fileSystem == null) {
-                logger.severe("Error build SCM file system");
-                return true;
-            }
-            
-            List<String> pathesList = new ArrayList<String>(collectAllAffectedFiles(getGitChangeSetListFromPrevious(fileSystem, head, prevRevision)));
-            // If there is match for at least one file run the build
-            for (String filePath : pathesList){
-    			for(String includedRegion:includedRegionsList) {    				
-    				if(SelectorUtils.matchPath(includedRegion, filePath)) {
-    					logger.info("Matched included region:" + includedRegion + " with file path:" + filePath);
-    					return true;
-    				}else {
-    					logger.fine("Not matched included region:" + includedRegion + " with file path:" + filePath);
-    				}
-    			}
-            }
-            
-            
-            return false;
-            
-        } catch (Exception e) {
-            //we don't want to cancel builds on unexpected exception
-        	logger.log(Level.SEVERE, "Unecpected exception", e);
-            return true;
+        String credentialsId = ghSource.getCredentialsId();
+        if (credentialsId != null) {
+          ActuallyUsefulGitHubSCMSource usefulSource = new ActuallyUsefulGitHubSCMSource(
+            ghSource.getId(),
+            ghSource.getApiUri(),
+            credentialsId,
+            credentialsId,
+            ghSource.getRepoOwner(),
+            ghSource.getRepository()
+          );
+
+          LogTaskListener listener = new LogTaskListener(Logger.getLogger(IncludeRegionBranchBuildStrategy.class.getName()), Level.INFO);
+          prevRevision = usefulSource.getCommitHash(targetHead, listener);
+          logger.fine(String.format("prevRevision after: %s", prevRevision));
         }
-        
-        
+      }
 
+      List<String> includedRegionsList = Arrays.stream(includedRegions.split("\n")).map(e -> e.trim()).collect(Collectors.toList());
+
+      logger.info(String.format("Included regions: %s", includedRegionsList.toString()));
+
+      // No regions included cancel the build
+      if(includedRegionsList.isEmpty()) {
+        logger.info("No included regions configured, not triggering the build");
+        return false;
+      }
+
+    	// Build SCM object
+    	SCM scm = source.build(head, currRevision);
+
+    	// Verify source owner
+    	SCMSourceOwner owner = source.getOwner();
+      if (owner == null) {
+        logger.severe("Error verify SCM source owner");
+        return true;
+      }
+
+      // Build SCM file system
+      SCMFileSystem fileSystem = buildSCMFileSystem(source,head,currRevision,scm,owner);
+      if (fileSystem == null) {
+        logger.severe("Error building SCM file system");
+        return true;
+      }
+
+      List<String> pathesList = new ArrayList<String>(collectAllAffectedFiles(getGitChangeSetListFromPrevious(fileSystem, head, prevRevision)));
+      // If there is match for at least one file run the build
+      for (String filePath : pathesList){
+  			for(String includedRegion:includedRegionsList) {
+  				if(SelectorUtils.matchPath(includedRegion, filePath)) {
+            logger.info("Triggering build, matched included region:" + includedRegion + " with file path:" + filePath);
+  					return true;
+  				} else {
+            logger.fine("Didn't match included region:" + includedRegion + " with file path:" + filePath);
+  				}
+  			}
+      }
+      logger.info("Didn't match any included regions, not triggering build");
+      return false;
+    } catch (Exception e) {
+      // We don't want to cancel builds on unexpected exception
+      logger.log(Level.SEVERE, "Unexpected exception", e);
+      return true;
     }
+  }
 
-    @Extension
-    public static class DescriptorImpl extends BranchBuildStrategyDescriptor {
-        public String getDisplayName() {
-            return "Build included regions strategy";
-        }
+  @Extension
+  public static class DescriptorImpl extends BranchBuildStrategyDescriptor {
+    public String getDisplayName() {
+      return "Build included regions strategy";
     }
-
+  }
 }


### PR DESCRIPTION
For new PRs prevRevision is set to null, which causes the plugin to create a diff of files changes based on all commits ever done to the repo.
Fix this for GitHub PullRequests by using the commit of the target branch as the revision to compare against. This way new PRs will no longer incorrectly trigger for not included regions and existing PRs will always trigger for every commit done to them if any commit in the PR/branch touches any files in the included regions.